### PR TITLE
Bugfix in RexProBaseConnection.close_transaction

### DIFF
--- a/rexpro/connectors/base.py
+++ b/rexpro/connectors/base.py
@@ -264,7 +264,8 @@ class RexProBaseConnection(object):
             raise exceptions.RexProScriptException("transaction is not open")
         self.execute(
             script='g.stopTransaction({})'.format('SUCCESS' if success else 'FAILURE'),
-            isolate=False
+            isolate=False,
+            transaction=False
         )
         self._in_transaction = False
 


### PR DESCRIPTION
There are a critical bug - when closing transaction, execute method used though transaction parameter isn't specified. It leads to usage of default True value, which in turn, forces Rexster Server to rollback current transaction before executing code that should commit transaction.
