### PR TITLE
allow language to be specified when executing a script

### DIFF
--- a/docs/examples/code/gremlin_python/graph_of_gods_examples.py
+++ b/docs/examples/code/gremlin_python/graph_of_gods_examples.py
@@ -1,0 +1,42 @@
+from rexpro import RexProConnection
+
+conn = RexProConnection('localhost', 8184, 'graph')
+
+conn.execute("""
+from com.thinkaurelius.titan.example import GraphOfTheGodsFactory
+from com.thinkaurelius.titan.core import SchemaViolationException
+
+try:
+    #Try to load up the graph of the gods if it's not already loaded
+    GraphOfTheGodsFactory.load(g.graph)
+except SchemaViolationException:
+    pass
+""", language='python')
+
+# Run some examples based on https://github.com/thinkaurelius/titan/wiki/Getting-Started
+# `as` and `in` have trailing underscores to avoid clashing with python keywords
+# whenever possible, naming conventions are the same as other gremlin language implementations
+saturn_grandchild = conn.execute("""
+g.V.has('name', 'saturn').in_('father').in_('father').name
+""", language='python')
+
+assert saturn_grandchild == ['hercules']
+
+saturn_grandchild = conn.execute("""
+g.V.has('name', 'saturn').as_('x').in_('father').loop('x', lambda it: it.loops < 3).name
+""", language='python')
+
+assert saturn_grandchild == ['hercules']
+
+hercules_parent_names = conn.execute("""
+g.V.has('name', 'saturn').in_('father').in_('father').out('father','mother').name
+""", language='python')
+
+assert set(hercules_parent_names) == {'jupiter', 'alcmene'}
+
+# find hercules' parents and return a list of their information as dictionaries
+hercules_parents = conn.execute("""
+list(g.V.has('name', 'saturn').in_('father').in_('father').out('father','mother').map())
+""", language='python')
+
+assert hercules_parents == [{'age': 5000, 'name': 'jupiter'}, {'age': 45, 'name': 'alcmene'}]

--- a/docs/examples/code/gremlin_python/management_system.py
+++ b/docs/examples/code/gremlin_python/management_system.py
@@ -1,0 +1,27 @@
+from rexpro import RexProConnection
+
+conn = RexProConnection('localhost', 8184, 'graph')
+
+# Use the management system to define properties and build indexes
+conn.execute("""
+from com.tinkerpop.blueprints import Vertex
+ms = g.management_system
+name = ms.make_property_key('name')
+age = ms.make_property_key('age', data_type=Integer)
+ms.build_index('by-name', Vertex, keys=[name])
+ms.build_index('by-name-and-age', Vertex, keys=[name, age])
+ms.commit()
+""", language='python')
+
+
+# the management system can also be used as a context manager with an implied commit when exiting the context
+# this might be desirable if you'd like to cut down on some typing or group different blocks of code in transactions
+conn.execute("""
+from com.tinkerpop.blueprints import Vertex
+with g.management_system as ms:
+    name = ms.make_property_key('name')
+    age = ms.make_property_key('age', data_type=Integer)
+    ms.build_index('by-name', Vertex, keys=[name])
+    ms.build_index('by-name-and-age', Vertex, keys=[name, age])
+""", language='python')
+

--- a/docs/examples/gremlin_python.rst
+++ b/docs/examples/gremlin_python.rst
@@ -1,0 +1,25 @@
+.. _example_gremlin_python:
+
+gremlin-python
+==============
+
+gremlin-python is a 3rd party script engine that's available for use with the rexster server.
+If you'd like to use python syntax when working with your graphs, you can install it by
+following these instructions: https://github.com/pokitdok/gremlin-python#rexster
+
+Here we illustrate submitting python scripts using rexpro
+
+graph of gods examples
+----------------------
+
+.. literalinclude:: code/gremlin_python/graph_of_gods_examples.py
+    :language: python
+    :linenos:
+
+management system
+-----------------
+
+.. literalinclude:: code/gremlin_python/management_system.py
+    :language: python
+    :linenos:
+

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,0 +1,13 @@
+.. _example_implementations:
+
+Examples
+========
+
+Common examples for using rexpro
+
+.. toctree::
+   :includehidden:
+   :maxdepth: 2
+
+   /quickstart
+   gremlin_python

--- a/rexpro/connectors/base.py
+++ b/rexpro/connectors/base.py
@@ -393,7 +393,8 @@ class RexProBaseConnection(object):
         else:
             self.close_transaction(True)
 
-    def execute(self, script, params=None, isolate=True, transaction=True):
+    def execute(self, script, params=None, isolate=True, transaction=True,
+                language=messages.ScriptRequest.Language.GROOVY):
         """
         executes the given gremlin script with the provided parameters
 
@@ -405,6 +406,8 @@ class RexProBaseConnection(object):
         :type isolate: bool
         :param transaction: query will be wrapped in a transaction if set to True (default)
         :type transaction: bool
+        :param language: the script language that should be used (defaults to groovy)
+        :type language: str
 
         :rtype: list
         """
@@ -418,6 +421,7 @@ class RexProBaseConnection(object):
                 session_key=self._session_key,
                 isolate=isolate,
                 in_transaction=transaction,
+                language=language
             )
         )
         response = self._conn.get_response()

--- a/rexpro/messages.py
+++ b/rexpro/messages.py
@@ -331,6 +331,7 @@ class ScriptRequest(RexProMessage):
         GROOVY = 'groovy'
         SCALA = 'scala'
         JAVA = 'java'
+        PYTHON = 'python'
 
     MESSAGE_TYPE = MessageTypes.SCRIPT_REQUEST
 


### PR DESCRIPTION
Hello,

We recently released https://github.com/pokitdok/gremlin-python
and we'd like to use rexpro to easily submit python scripts to rexster for execution.
(https://github.com/pokitdok/gremlin-python#rexster)
It looks like everything is in place to do this now and we just needed to allow the `language` parameter to be passed in when running `execute`

I ran the tests locally and all of the current tests still passed:
```
corbinbs@~/Projects/github/rexpro-python (venv) [master] $ nosetests
............................................................
----------------------------------------------------------------------
Ran 60 tests in 6.863s

OK
```

please consider adding this so folks that drop gremlin-python into their rexster server can easily execute python scripts with rexpro.


Thanks for the great rexpro python library!

Brian